### PR TITLE
Use ktor, close channel

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+val ktor_version: String by project
+
 plugins {
     id("org.graalvm.buildtools.native") version "0.9.20"
     kotlin("jvm") version "1.8.20"
@@ -17,6 +19,9 @@ repositories {
 dependencies {
     // coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0-RC")
+
+    implementation("io.ktor:ktor-client-core:$ktor_version")
+    implementation("io.ktor:ktor-client-cio:$ktor_version")
 
     // http4k for requests and server
     implementation(platform("org.http4k:http4k-bom:4.42.1.0"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+ktor_version=2.3.0

--- a/src/main/kotlin/com/valbaca/gotlin/ch1/FetchAll.kt
+++ b/src/main/kotlin/com/valbaca/gotlin/ch1/FetchAll.kt
@@ -1,13 +1,15 @@
 package com.valbaca.gotlin.ch1
 
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.http4k.client.ApacheClient
-import org.http4k.core.Method
-import org.http4k.core.Request
 import java.time.Duration.between
 import java.time.Instant.now
 
@@ -19,25 +21,27 @@ fun main(args: Array<String>) {
         arrayOf("https://www.google.com", "https://go.dev", "https://kotlinlang.org/", "https://gopl.io", "https://www.http4k.org/")
     }
     val start = now()
+    val client = HttpClient(CIO)
     val ch = Channel<String>()
     runBlocking(Dispatchers.Default) {
-        for (url in urls) {
-            fetch(url, ch)
+        launch {
+            for (url in urls) {
+                fetch(client, url, ch)
+            }
+        }.invokeOnCompletion {
+            ch.close()
         }
-        repeat(urls.size) {
-            println(ch.receive())
-        }
+
+        ch.consumeEach { println(it) }
     }
     println("${between(start, now()).toMillis()}ms elapsed")
 }
 
-fun CoroutineScope.fetch(url: String, ch: Channel<String>) = launch {
+fun CoroutineScope.fetch(client: HttpClient, url: String, ch: Channel<String>) = launch {
     val start = now()
     try {
-        val http = ApacheClient()
-        val req = Request(Method.GET, url)
-        val res = http(req)
-        val n = res.body.length!!
+        val response = client.get(url)
+        val n = response.body<ByteArray>().size
         ch.send("${between(start, now()).toMillis()}ms $n $url")
     } catch (e: Exception) {
         ch.send("${between(start, now()).toMillis()}ms Exception ${e.message}")


### PR DESCRIPTION
Ktor participates in the coroutine system. The calls look synchronous, but actually suspend the current thread until they complete and then continue once the IO completes. This is closer to how the go runtime works.

Also, I did a little trick to close the channel once all the calls complete by wrapping them all in a launch and closing once that completes. The result is the same as the previous code, but the consume doesn't depend on knowing the number of inputs. I can't really say which is "better", but it's another way to approach the problem.